### PR TITLE
Added FocusScope.of(context).unfocus()

### DIFF
--- a/lib/credit_card_form.dart
+++ b/lib/credit_card_form.dart
@@ -284,6 +284,7 @@ class _CreditCardFormState extends State<CreditCardForm> {
                 keyboardType: TextInputType.text,
                 textInputAction: TextInputAction.done,
                 onEditingComplete: () {
+                  FocusScope.of(context).unfocus();
                   onCreditCardModelChange(creditCardModel);
                 },
               ),


### PR DESCRIPTION
added unfocus function on the onEditingComplete function of the CardHolderName TextFormField.