### PR TITLE
feat: Added formfield keys for manual field validation checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
-## 3.0.1 - Sep 28, 2021 [Unreleased]
+## 3.0.1 - Oct 12, 2021
+
+- Fixed [#40](https://github.com/SimformSolutionsPvtLtd/flutter_credit_card/issues/40) - Absence of focus node in credit_card_form.dart
 - Fixed [#57](https://github.com/SimformSolutionsPvtLtd/flutter_credit_card/issues/57) - Can we specify a custom card type logos
+- License update from BSD 2-Clause "Simplified" to MIT
 
 ## 3.0.0 - Sep 23, 2021
 

--- a/lib/credit_card_form.dart
+++ b/lib/credit_card_form.dart
@@ -126,38 +126,6 @@ class _CreditCardFormState extends State<CreditCardForm> {
     onCreditCardModelChange = widget.onCreditCardModelChange;
 
     cvvFocusNode.addListener(textFieldFocusDidChange);
-
-    _cardNumberController.addListener(() {
-      setState(() {
-        cardNumber = _cardNumberController.text;
-        creditCardModel.cardNumber = cardNumber;
-        onCreditCardModelChange(creditCardModel);
-      });
-    });
-
-    _expiryDateController.addListener(() {
-      setState(() {
-        expiryDate = _expiryDateController.text;
-        creditCardModel.expiryDate = expiryDate;
-        onCreditCardModelChange(creditCardModel);
-      });
-    });
-
-    _cardHolderNameController.addListener(() {
-      setState(() {
-        cardHolderName = _cardHolderNameController.text;
-        creditCardModel.cardHolderName = cardHolderName;
-        onCreditCardModelChange(creditCardModel);
-      });
-    });
-
-    _cvvCodeController.addListener(() {
-      setState(() {
-        cvvCode = _cvvCodeController.text;
-        creditCardModel.cvvCode = cvvCode;
-        onCreditCardModelChange(creditCardModel);
-      });
-    });
   }
 
   @override
@@ -194,6 +162,13 @@ class _CreditCardFormState extends State<CreditCardForm> {
                   key: widget.cardNumberKey,
                   obscureText: widget.obscureNumber,
                   controller: _cardNumberController,
+                  onChanged: (String value) {
+                    setState(() {
+                      cardNumber = _cardNumberController.text;
+                      creditCardModel.cardNumber = cardNumber;
+                      onCreditCardModelChange(creditCardModel);
+                    });
+                  },
                   cursorColor: widget.cursorColor ?? themeColor,
                   onEditingComplete: () {
                     FocusScope.of(context).requestFocus(expiryDateNode);
@@ -227,6 +202,13 @@ class _CreditCardFormState extends State<CreditCardForm> {
                       child: TextFormField(
                         key: widget.expiryDateKey,
                         controller: _expiryDateController,
+                        onChanged: (String value) {
+                          setState(() {
+                            expiryDate = _expiryDateController.text;
+                            creditCardModel.expiryDate = expiryDate;
+                            onCreditCardModelChange(creditCardModel);
+                          });
+                        },
                         cursorColor: widget.cursorColor ?? themeColor,
                         focusNode: expiryDateNode,
                         onEditingComplete: () {
@@ -294,6 +276,8 @@ class _CreditCardFormState extends State<CreditCardForm> {
                       onChanged: (String text) {
                         setState(() {
                           cvvCode = text;
+                          creditCardModel.cvvCode = cvvCode;
+                          onCreditCardModelChange(creditCardModel);
                         });
                       },
                       validator: (String? value) {
@@ -315,6 +299,13 @@ class _CreditCardFormState extends State<CreditCardForm> {
                 child: TextFormField(
                   key: widget.cardHolderKey,
                   controller: _cardHolderNameController,
+                  onChanged: (String value) {
+                    setState(() {
+                      cardHolderName = _cardHolderNameController.text;
+                      creditCardModel.cardHolderName = cardHolderName;
+                      onCreditCardModelChange(creditCardModel);
+                    });
+                  },
                   cursorColor: widget.cursorColor ?? themeColor,
                   focusNode: cardHolderNode,
                   style: TextStyle(

--- a/lib/credit_card_form.dart
+++ b/lib/credit_card_form.dart
@@ -34,6 +34,10 @@ class CreditCardForm extends StatefulWidget {
       hintText: 'XXX',
     ),
     required this.formKey,
+    this.cardNumberKey,
+    this.cardHolderKey,
+    this.expiryDateKey,
+    this.cvvCodeKey,
     this.cvvValidationMessage = 'Please input a valid CVV',
     this.dateValidationMessage = 'Please input a valid date',
     this.numberValidationMessage = 'Please input a valid number',
@@ -59,6 +63,11 @@ class CreditCardForm extends StatefulWidget {
   final bool isCardNumberVisible;
   final bool isExpiryDateVisible;
   final GlobalKey<FormState> formKey;
+
+  final GlobalKey<FormFieldState<String>>? cardNumberKey;
+  final GlobalKey<FormFieldState<String>>? cardHolderKey;
+  final GlobalKey<FormFieldState<String>>? expiryDateKey;
+  final GlobalKey<FormFieldState<String>>? cvvCodeKey;
 
   final InputDecoration cardNumberDecoration;
   final InputDecoration cardHolderDecoration;
@@ -182,6 +191,7 @@ class _CreditCardFormState extends State<CreditCardForm> {
                 padding: const EdgeInsets.symmetric(vertical: 8.0),
                 margin: const EdgeInsets.only(left: 16, top: 16, right: 16),
                 child: TextFormField(
+                  key: widget.cardNumberKey,
                   obscureText: widget.obscureNumber,
                   controller: _cardNumberController,
                   cursorColor: widget.cursorColor ?? themeColor,
@@ -215,6 +225,7 @@ class _CreditCardFormState extends State<CreditCardForm> {
                       margin:
                           const EdgeInsets.only(left: 16, top: 8, right: 16),
                       child: TextFormField(
+                        key: widget.expiryDateKey,
                         controller: _expiryDateController,
                         cursorColor: widget.cursorColor ?? themeColor,
                         focusNode: expiryDateNode,
@@ -256,6 +267,7 @@ class _CreditCardFormState extends State<CreditCardForm> {
                     padding: const EdgeInsets.symmetric(vertical: 8.0),
                     margin: const EdgeInsets.only(left: 16, top: 8, right: 16),
                     child: TextFormField(
+                      key: widget.cvvCodeKey,
                       obscureText: widget.obscureCvv,
                       focusNode: cvvFocusNode,
                       controller: _cvvCodeController,
@@ -301,6 +313,7 @@ class _CreditCardFormState extends State<CreditCardForm> {
                 padding: const EdgeInsets.symmetric(vertical: 8.0),
                 margin: const EdgeInsets.only(left: 16, top: 8, right: 16),
                 child: TextFormField(
+                  key: widget.cardHolderKey,
                   controller: _cardHolderNameController,
                   cursorColor: widget.cursorColor ?? themeColor,
                   focusNode: cardHolderNode,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_credit_card
 description: A Credit Card widget package, support entering card details, card flip animation.
-version: 3.0.0
+version: 3.0.1
 homepage: https://github.com/simformsolutions/flutter_credit_card
 issue_tracker: https://github.com/simformsolutions/flutter_credit_card/issues
 


### PR DESCRIPTION
Sample use-cases:
- Upon entering card number, show check indicating field valid
- Validate form fields manually & enable 'save' or 'update' card buttons.

Upon entering all required information, calling `formKey.currentState.validate()` on each `onCreditCardModelChange` changed validates every field showing all error message, bad UX.

Allowing separate form field keys gives control to developer validating separate fields as required.