### PR TITLE
Remove Theme override in form

### DIFF
--- a/lib/credit_card_form.dart
+++ b/lib/credit_card_form.dart
@@ -158,12 +158,7 @@ class _CreditCardFormState extends State<CreditCardForm> {
 
   @override
   Widget build(BuildContext context) {
-    return Theme(
-      data: ThemeData(
-        primaryColor: themeColor.withOpacity(0.8),
-        primaryColorDark: themeColor,
-      ),
-      child: Form(
+    return Form(
         key: widget.formKey,
         child: Column(
           children: <Widget>[
@@ -359,7 +354,6 @@ class _CreditCardFormState extends State<CreditCardForm> {
             ),
           ],
         ),
-      ),
     );
   }
 }


### PR DESCRIPTION
Overriding the theme makes little sense, not inheriting from the application theme does not either. The current behavior of the form widget is to recreate a theme from scratch by using the current primary color, which discards other aspects of the application theme. In doing so that widget requires input decorators to be passed into the form widget which is not needed.

This PR removes the `Theme` override in the form widget, which allows to keep inheriting from the app theme.

If someone wants a theme to differ from the original application theme they can do so with the standard mechanism of wrapping this widget outside the package with a `Theme` widget instead of being locked by this package which does not actually inherit the application theme (only a variant of the primary color).

This also mean that all the input decorations are not needed anymore, except if someone would like to style one individual input, which I doubt is a coherent use case. I let those field so this is not a breaking change and outside the scope of this PR.