### PR TITLE
Fix: :bug: Add a flag to disable autofill hints for credit card number to fix incorrect keyboard for credit card number.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# [3.0.6](https://github.com/SimformSolutionsPvtLtd/flutter_credit_card/tree/3.0.6)
+
+- Add documentation for public apis.
+- Fixed [#126](https://github.com/SimformSolutionsPvtLtd/flutter_credit_card/issues/126) Added a flag to disable autofill hints for credit card number as workaround to fix incorrect keyboard.
+- Enhancement [#129](https://github.com/SimformSolutionsPvtLtd/flutter_credit_card/pull/129) Obscure initial character in credit card widget
+
 # [3.0.5](https://github.com/SimformSolutionsPvtLtd/flutter_credit_card/tree/3.0.5)
 
 - New card brands (Elo/Hipercard) was added [#109](https://github.com/SimformSolutionsPvtLtd/flutter_credit_card/pull/109) 

--- a/lib/credit_card_form.dart
+++ b/lib/credit_card_form.dart
@@ -46,6 +46,7 @@ class CreditCardForm extends StatefulWidget {
     this.cvvValidator,
     this.cardHolderValidator,
     this.onFormComplete,
+    this.disableCardNumberAutoFillHints = false,
   }) : super(key: key);
 
   /// A string indicating card number in the text field.
@@ -146,6 +147,17 @@ class CreditCardForm extends StatefulWidget {
 
   /// A validator for card holder text field.
   final String? Function(String?)? cardHolderValidator;
+
+  /// Setting this flag to true will disable autofill hints for Credit card
+  /// number text field. Flutter has a bug when auto fill hints are enabled for
+  /// credit card numbers it shows keyboard with characters. But, disabling
+  /// auto fill hints will show correct keyboard.
+  ///
+  /// Defaults to false.
+  ///
+  /// You can follow the issue here
+  /// [https://github.com/flutter/flutter/issues/104604](https://github.com/flutter/flutter/issues/104604).
+  final bool disableCardNumberAutoFillHints;
 
   @override
   _CreditCardFormState createState() => _CreditCardFormState();
@@ -257,7 +269,9 @@ class _CreditCardFormState extends State<CreditCardForm> {
                   decoration: widget.cardNumberDecoration,
                   keyboardType: TextInputType.number,
                   textInputAction: TextInputAction.next,
-                  autofillHints: const <String>[AutofillHints.creditCardNumber],
+                  autofillHints: widget.disableCardNumberAutoFillHints
+                      ? null
+                      : const <String>[AutofillHints.creditCardNumber],
                   autovalidateMode: widget.autovalidateMode,
                   validator: widget.cardNumberValidator ??
                       (String? value) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_credit_card
 description: A Credit Card widget package, support entering card details, card flip animation.
-version: 3.0.5
+version: 3.0.6
 homepage: https://github.com/simformsolutions/flutter_credit_card
 issue_tracker: https://github.com/simformsolutions/flutter_credit_card/issues
 


### PR DESCRIPTION
Fixes #126 