### PR TITLE
Added support for Dart 3

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -14,7 +14,7 @@ class MySample extends StatefulWidget {
 
 class MySampleState extends State<MySample> {
   String cardNumber = '';
-  String expiryDate = '';
+  (int?, int?) expiryDate = (0, 0);
   String cardHolderName = '';
   String cvvCode = '';
   bool isCvvFocused = false;
@@ -43,6 +43,7 @@ class MySampleState extends State<MySample> {
         primarySwatch: Colors.blue,
       ),
       home: Scaffold(
+        appBar: AppBar(),
         resizeToAvoidBottomInset: false,
         body: Container(
           decoration: const BoxDecoration(

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -14,7 +14,7 @@ publish_to: none
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
   flutter:

--- a/lib/credit_card_form.dart
+++ b/lib/credit_card_form.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_credit_card/extension.dart';
 import 'package:flutter_credit_card/flutter_credit_card.dart';
 
 class CreditCardForm extends StatefulWidget {
@@ -53,8 +54,8 @@ class CreditCardForm extends StatefulWidget {
   /// A string indicating card number in the text field.
   final String cardNumber;
 
-  /// A string indicating expiry date in the text field.
-  final String expiryDate;
+  /// Records indicating expiry date in the text field.
+  final (int?, int?) expiryDate;
 
   /// A string indicating card holder name in the text field.
   final String cardHolderName;
@@ -170,7 +171,7 @@ class CreditCardForm extends StatefulWidget {
 
 class _CreditCardFormState extends State<CreditCardForm> {
   late String cardNumber;
-  late String expiryDate;
+  late (int?, int?) expiryDate;
   late String cardHolderName;
   late String cvvCode;
   bool isCvvFocused = false;
@@ -214,7 +215,7 @@ class _CreditCardFormState extends State<CreditCardForm> {
     createCreditCardModel();
 
     _cardNumberController.text = widget.cardNumber;
-    _expiryDateController.text = widget.expiryDate;
+    _expiryDateController.text = widget.expiryDate.toStringValue;
     _cardHolderNameController.text = widget.cardHolderName;
     _cvvCodeController.text = widget.cvvCode;
 
@@ -308,7 +309,7 @@ class _CreditCardFormState extends State<CreditCardForm> {
                                 '0' + _expiryDateController.text;
                           }
                           setState(() {
-                            expiryDate = _expiryDateController.text;
+                            expiryDate = _expiryDateController.text.toRecordValue;
                             creditCardModel.expiryDate = expiryDate;
                             onCreditCardModelChange(creditCardModel);
                           });

--- a/lib/credit_card_model.dart
+++ b/lib/credit_card_model.dart
@@ -6,7 +6,7 @@ class CreditCardModel {
   String cardNumber = '';
 
   /// Expiry date of the card.
-  String expiryDate = '';
+  (int?, int?) expiryDate;
 
   /// Name of the card holder.
   String cardHolderName = '';

--- a/lib/credit_card_widget.dart
+++ b/lib/credit_card_widget.dart
@@ -60,7 +60,7 @@ class CreditCardWidget extends StatefulWidget {
   final String cardNumber;
 
   /// A string indicating expiry date for the card.
-  final String expiryDate;
+  final (int?, int?) expiryDate;
 
   /// A string indicating name of the card holder.
   final String cardHolderName;
@@ -403,7 +403,7 @@ class _CreditCardWidgetState extends State<CreditCardWidget>
             child: Padding(
               padding: const EdgeInsets.only(left: 16),
               child: Text(
-                widget.cardNumber.isEmpty ? 'XXXX XXXX XXXX XXXX' : number,
+                widget.cardNumber.toNumber.isEmpty ? 'XXXX XXXX XXXX XXXX' : number,
                 style: widget.textStyle ?? defaultTextStyle,
               ),
             ),
@@ -424,9 +424,9 @@ class _CreditCardWidgetState extends State<CreditCardWidget>
                   ),
                   const SizedBox(width: 5),
                   Text(
-                    widget.expiryDate.isEmpty
+                    widget.expiryDate.toStringValue.isEmpty
                         ? widget.labelExpiredDate
-                        : widget.expiryDate,
+                        : widget.expiryDate.toStringValue,
                     style: widget.textStyle ?? defaultTextStyle,
                   ),
                 ],
@@ -670,7 +670,7 @@ class _CreditCardWidgetState extends State<CreditCardWidget>
             // Convert the prefix range into numbers then make sure the
             // Credit Card num is in the pattern range.
             // Because Strings don't have '>=' type operators
-            final int ccPrefixAsInt = int.parse(ccPatternStr);
+            final int ccPrefixAsInt = int.tryParse(ccPatternStr) ?? 0;
             final int startPatternPrefixAsInt = int.parse(patternRange[0]);
             final int endPatternPrefixAsInt = int.parse(patternRange[1]);
             if (ccPrefixAsInt >= startPatternPrefixAsInt &&

--- a/lib/extension.dart
+++ b/lib/extension.dart
@@ -3,3 +3,28 @@ extension NullableStringExtension on String? {
 
   bool get isNotNullAndNotEmpty => this != null && (this?.isNotEmpty ?? false);
 }
+
+extension StringExtension on String {
+
+  String get toDate {
+    return padLeft(2, '0').substring(0, 2);
+  }
+
+  String get toNumber {
+    if (int.tryParse(this) != null && double.tryParse(this) != null)
+      return this;
+    return '';
+  }
+
+  (int?, int?) get toRecordValue {
+    if (contains('/'))
+      return (int.tryParse(split('/').first), int.tryParse(split('/').last));
+    return (null, null);
+  }
+}
+
+extension RecordsExtension on (int?, int?) {
+  String get toStringValue {
+    return '${(this.$1 ?? "MM").toString().toDate}/${(this.$2 ?? "YY").toString().toDate}';
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/simformsolutions/flutter_credit_card
 issue_tracker: https://github.com/simformsolutions/flutter_credit_card/issues
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
   flutter:


### PR DESCRIPTION
In this pr, the sdk was updated for Dart 3, with that the type of expiryDate was changed from a String to a Record, thus allowing to insert only two values, one for the Month and another for the year, thus preventing users to define a text that is not in Expiration Date Format or is not a number.

Also fixed issue #135 by refracting parts of the code and adding ways to prevent the issue from happening.