### PR TITLE
added ability to specify card 'status'

### DIFF
--- a/lib/src/credit_card_widget.dart
+++ b/lib/src/credit_card_widget.dart
@@ -31,6 +31,7 @@ class CreditCardWidget extends StatefulWidget {
     required this.showBackView,
     required this.onCreditCardWidgetChange,
     this.bankName,
+    this.cardStatus,
     this.animationDuration = AppConstants.defaultAnimDuration,
     this.height,
     this.width,
@@ -83,6 +84,9 @@ class CreditCardWidget extends StatefulWidget {
 
   /// A string indicating name of the bank.
   final String? bankName;
+
+  /// A string indicating status of the card (Platinum, Gold, etc.)
+  final String? cardStatus;
 
   /// Duration for flip animation. Defaults to 500 milliseconds.
   final Duration animationDuration;
@@ -465,6 +469,69 @@ class _CreditCardWidgetState extends State<CreditCardWidget>
     );
   }
 
+  Widget _frontCardTopRow(TextStyle defaultTextStyle) {
+    Padding? cardStylePadding;
+    Padding? bankNamePadding;
+
+    if (widget.bankName.isNotNullAndNotEmpty) {
+      bankNamePadding = _frontCardBankNameWidget(defaultTextStyle);
+    }
+
+    if (widget.cardStatus.isNotNullAndNotEmpty) {
+      cardStylePadding = _frontCardStatusWidget(defaultTextStyle);
+    }
+
+    if (cardStylePadding != null && bankNamePadding != null) {
+      return Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          cardStylePadding,
+          bankNamePadding,
+        ],
+      );
+    }
+
+    if (cardStylePadding != null) {
+      return Align(
+        alignment: Alignment.topLeft,
+        child: cardStylePadding,
+      );
+    }
+
+    if (bankNamePadding != null) {
+      return Align(
+        alignment: Alignment.topRight,
+        child: bankNamePadding,
+      );
+    }
+
+    return const SizedBox();
+  }
+
+  Padding _frontCardStatusWidget(TextStyle defaultTextStyle) {
+    return Padding(
+      padding: const EdgeInsets.only(left: 16, top: 16),
+      child: Text(
+        widget.cardStatus!,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: defaultTextStyle,
+      ),
+    );
+  }
+
+  Padding _frontCardBankNameWidget(TextStyle defaultTextStyle) {
+    return Padding(
+      padding: const EdgeInsets.only(right: 16, top: 16),
+      child: Text(
+        widget.bankName!,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: defaultTextStyle,
+      ),
+    );
+  }
+
   Widget _frontCardBackground({
     required String number,
     required TextStyle defaultTextStyle,
@@ -484,19 +551,7 @@ class _CreditCardWidgetState extends State<CreditCardWidget>
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
-          if (widget.bankName.isNotNullAndNotEmpty)
-            Align(
-              alignment: Alignment.topRight,
-              child: Padding(
-                padding: const EdgeInsets.only(right: 16, top: 16),
-                child: Text(
-                  widget.bankName!,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: defaultTextStyle,
-                ),
-              ),
-            ),
+          _frontCardTopRow(defaultTextStyle),
           Expanded(
             flex: widget.isChipVisible ? 1 : 0,
             child: Row(


### PR DESCRIPTION
This pull request adds an ability to specify the 'status' of the card, similar to this:
![](https://www.adib.eg/media/101965/internalcards/04730-v2-ADIB-Mastercard-platinum-Debit-Contactless.png)
(this image was obtained by googling "mastercard platinum")

When:
```dart
return CreditCardWidget(
  bankName: 'ADCB',
  cardStatus: 'Platinum',
);
```

![image](https://github.com/SimformSolutionsPvtLtd/flutter_credit_card/assets/1318627/13b822f2-2fef-4351-ba32-3c4812cf154c)


When:
```dart
return CreditCardWidget(
  bankName: 'ADCB',
);
```
![image](https://github.com/SimformSolutionsPvtLtd/flutter_credit_card/assets/1318627/b8d0b568-e581-4e4e-9df7-30543957f1cd)


When:
```dart
return CreditCardWidget(
  cardStatus: 'Platinum',
);
```
![image](https://github.com/SimformSolutionsPvtLtd/flutter_credit_card/assets/1318627/937d623e-173c-44b5-a77d-e9c4a73a957c)
