### PR TITLE
CreditCardWidget textColor

### DIFF
--- a/lib/src/credit_card_widget.dart
+++ b/lib/src/credit_card_widget.dart
@@ -35,6 +35,7 @@ class CreditCardWidget extends StatefulWidget {
     this.height,
     this.width,
     this.textStyle,
+    this.textColor,
     this.cardBgColor = AppConstants.defaultCardBgColor,
     this.obscureCardNumber = true,
     this.obscureCardCvv = true,
@@ -73,6 +74,9 @@ class CreditCardWidget extends StatefulWidget {
 
   /// Applies text style to cardNumber, expiryDate, cardHolderName and cvvCode.
   final TextStyle? textStyle;
+
+  /// Applies text color to cardNumber, expiryDate, cardHolderName and cvvCode.
+  final Color? textColor;
 
   /// Applies background color for card UI.
   final Color cardBgColor;
@@ -297,7 +301,7 @@ class _CreditCardWidgetState extends State<CreditCardWidget>
         _cardGesture(
           child: FlipAnimationBuilder(
             animation: _frontRotation,
-            child: _buildFrontContainer(),
+            child: _buildFrontContainer(widget.textColor),
           ),
         ),
         _cardGesture(
@@ -423,11 +427,11 @@ class _CreditCardWidgetState extends State<CreditCardWidget>
   /// Builds a front container containing
   /// Card number, Exp. year and Card holder name
   ///
-  Widget _buildFrontContainer() {
+  Widget _buildFrontContainer(Color? textColor) {
     final TextStyle defaultTextStyle =
         Theme.of(context).textTheme.titleLarge!.merge(
-              const TextStyle(
-                color: Colors.white,
+              TextStyle(
+                color: textColor ?? Colors.white,
                 fontFamily: AppConstants.fontFamily,
                 fontSize: 15,
                 package: AppConstants.packageName,


### PR DESCRIPTION
If I want to change only the text color of the CreditCardWidget I have to change the textStyle, but if I change the textStyle the label 'Valid Thru' loses its font size
![Simulator Screenshot - iPhone 15 Pro Max - 2024-04-24 at 17 00 31](https://github.com/SimformSolutionsPvtLtd/flutter_credit_card/assets/93768837/afb898d8-52fb-4e9b-8914-bb6ecc0a5291)
So I added a property textColor that allows changing only the textColor without changing the entire textStyle
![Simulator Screenshot - iPhone 15 Pro Max - 2024-04-24 at 17 01 19](https://github.com/SimformSolutionsPvtLtd/flutter_credit_card/assets/93768837/c49d149a-5c83-47c8-94a6-bedb116cafed)
