### PR TITLE
[Android] Fix nullable sensor issue in GyroscopeStreamHandler

### DIFF
--- a/android/src/main/kotlin/com/simform/flutter_credit_card/gyroscope/GyroscopeStreamHandler.kt
+++ b/android/src/main/kotlin/com/simform/flutter_credit_card/gyroscope/GyroscopeStreamHandler.kt
@@ -15,9 +15,9 @@ internal class GyroscopeStreamHandler(
 ) : EventChannel.StreamHandler {
     private var sensorEventListener: SensorEventListener? = null
 
-    private val sensor: Sensor by lazy {
-        sensorManager.getDefaultSensor(Sensor.TYPE_GYROSCOPE)
-    }
+   
+    private val sensor: Sensor = sensorManager.getDefaultSensor(Sensor.TYPE_GYROSCOPE)
+        ?: throw IllegalStateException("Gyroscope sensor not available")
 
     override fun onListen(arguments: Any?, events: EventSink) {
         sensorEventListener = createSensorEventListener(events)


### PR DESCRIPTION
- Updated the sensor property to ensure it is non-nullable by throwing an IllegalStateException if the gyroscope sensor is not available.
- This change resolves compilation errors related to nullable type.

What was the issue ?
The issue occurred when running the project with this package added on  Flutter Channel stable 3.24.1

Trace:
```
Note: Recompile with -Xlint:deprecation for details.
file:///Users/waleed/.pub-cache/hosted/pub.dev/flutter_credit_card-4.0.1/android/src/main/kotlin/com/simform/flutter_credit_card/gyroscope/GyroscopeStreamHandler.kt:18:35 Function 'getValue' of property delegate is expected to return 'android.hardware.Sensor', but returns 'android.hardware.Sensor?'.
```


Running on debug/release produced the same issue 

Disclaimer: I'm not a Kotlin expert, applied the fix so I can continue working on my project, therefore Any suggestions/changes are welcome
