### PR TITLE
Fix: Add Namespace to build.gradle for :flutter_credit_card

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,12 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'com.simform.flutter_credit_card'
+    }
+
     compileSdk 31
 
     compileOptions {


### PR DESCRIPTION
Issue: Build failed due to missing namespace in the :flutter_credit_card module's build.gradle file.

Solution: Added the required namespace property to build.gradle as specified in [Android's documentation](https://d.android.com/r/tools/upgrade-assistant/set-namespace).

Outcome: The build now completes successfully without errors.
@meetjanani-simformsolutions @kaoz70 @kika @vHanda @guicarvalho @BirjuVachhani @DevarshRanpara