### PR TITLE
🐛 FIX: Namespace added to build.gradle for compatibility wih AGP

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,9 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    //Added compatibility wih AGP
+    namespace 'com.simform.flutter_credit_card'
+
     compileSdk 31
 
     compileOptions {


### PR DESCRIPTION
Issue: The absence of the namespace in the :flutter_credit_card module's build.gradle causes build errors with the latest Android Gradle Plugin. 

Fix: Added the namespace line to the Android block in the build.gradle file. [Android'AGP Doc](https://d.android.com/r/tools/upgrade-assistant/agp-upgrade-assistant)

Result: The build now runs successfully without issues.